### PR TITLE
rework of MIP texture generation

### DIFF
--- a/im_color.cc
+++ b/im_color.cc
@@ -343,7 +343,7 @@ byte COL_FindColor(const byte *palette, u32_t rgb_col)
   return COL_FindColor(palette, rgb_col, nullptr);
 }
 
-byte COL_FindColor(const byte *palette, u32_t rgb_col, bool *allowed_colors)
+byte COL_FindColor(const byte *palette, u32_t rgb_col, bool *colors_allowed)
 {
   int best_idx  = -1;
   int best_dist = (1<<30);
@@ -360,7 +360,7 @@ byte COL_FindColor(const byte *palette, u32_t rgb_col, bool *allowed_colors)
   for (int i = max_col; i >= min_col; i--)
   {
     // if an array of allowed colors is provided, skip colors not allowed
-    if(allowed_colors != nullptr && !allowed_colors[i])
+    if(colors_allowed != nullptr && !colors_allowed[i])
     {
       continue;
     }
@@ -392,7 +392,7 @@ byte COL_MapColor(u32_t rgb_col)
   return COL_MapColor(rgb_col, nullptr);
 }
 
-byte COL_MapColor(u32_t rgb_col, bool *allowed_colors)
+byte COL_MapColor(u32_t rgb_col, bool *colors_allowed)
 {
   if (RGB_A(rgb_col) <= 128)
     return transparent_color;
@@ -409,7 +409,7 @@ byte COL_MapColor(u32_t rgb_col, bool *allowed_colors)
     color_cache.clear();
   }
 
-  byte pal_idx = COL_FindColor(palette, rgb_col, allowed_colors);
+  byte pal_idx = COL_FindColor(palette, rgb_col, colors_allowed);
 
   color_cache[rgb_col] = pal_idx;
 

--- a/im_color.cc
+++ b/im_color.cc
@@ -338,8 +338,12 @@ u32_t COL_ReadPalWithTrans(byte pix)
   return MAKE_RGB(R, G, B);
 }
 
-
 byte COL_FindColor(const byte *palette, u32_t rgb_col)
+{
+  return COL_FindColor(palette, rgb_col, nullptr);
+}
+
+byte COL_FindColor(const byte *palette, u32_t rgb_col, bool *allowed_colors)
 {
   int best_idx  = -1;
   int best_dist = (1<<30);
@@ -350,8 +354,15 @@ byte COL_FindColor(const byte *palette, u32_t rgb_col)
   int min_col = (game_type == GAME_Quake1) ? 1 : 0;
   int max_col = allow_fullbright ? 255 : 255-32;
 
+  // TODO: investigate if we should count *backwards* to give fullbright colors priority
   for (int i = min_col; i <= max_col; i++)
   {
+    // if an array of allowed colors is provided, skip colors not allowed
+    if(allowed_colors != nullptr && !allowed_colors[i])
+    {
+      continue;
+    }
+
     int dr = RGB_R(rgb_col) - palette[i*3+2];
     int dg = RGB_G(rgb_col) - palette[i*3+1];
     int db = RGB_B(rgb_col) - palette[i*3+0];
@@ -374,8 +385,12 @@ byte COL_FindColor(const byte *palette, u32_t rgb_col)
   return best_idx;
 }
 
-
 byte COL_MapColor(u32_t rgb_col)
+{
+  return COL_MapColor(rgb_col, nullptr);
+}
+
+byte COL_MapColor(u32_t rgb_col, bool *allowed_colors)
 {
   if (RGB_A(rgb_col) <= 128)
     return transparent_color;
@@ -392,7 +407,7 @@ byte COL_MapColor(u32_t rgb_col)
     color_cache.clear();
   }
 
-  byte pal_idx = COL_FindColor(palette, rgb_col);
+  byte pal_idx = COL_FindColor(palette, rgb_col, allowed_colors);
 
   color_cache[rgb_col] = pal_idx;
 

--- a/im_color.cc
+++ b/im_color.cc
@@ -354,8 +354,10 @@ byte COL_FindColor(const byte *palette, u32_t rgb_col, bool *allowed_colors)
   int min_col = (game_type == GAME_Quake1) ? 1 : 0;
   int max_col = allow_fullbright ? 255 : 255-32;
 
-  // TODO: investigate if we should count *backwards* to give fullbright colors priority
-  for (int i = min_col; i <= max_col; i++)
+  // iterate through the color palette *backwards*, so that fullbright colors
+  // have precedence over non-fullbright colors
+  // (of course only if fullbright colors are enabled)
+  for (int i = max_col; i >= min_col; i--)
   {
     // if an array of allowed colors is provided, skip colors not allowed
     if(allowed_colors != nullptr && !allowed_colors[i])

--- a/im_color.h
+++ b/im_color.h
@@ -28,7 +28,9 @@ void COL_SetFullBright(bool enable);
 void COL_SetTransparent(byte pix);
 
 byte COL_FindColor(const byte *palette, u32_t rgb_col);
+byte COL_FindColor(const byte *palette, u32_t rgb_col, bool *allowed_colors);
 byte COL_MapColor(u32_t rgb_col);
+byte COL_MapColor(u32_t rgb_col, bool *allowed_colors);
 
 void COL_LoadPaletteFromFile(const char *filename);
 

--- a/im_color.h
+++ b/im_color.h
@@ -28,9 +28,9 @@ void COL_SetFullBright(bool enable);
 void COL_SetTransparent(byte pix);
 
 byte COL_FindColor(const byte *palette, u32_t rgb_col);
-byte COL_FindColor(const byte *palette, u32_t rgb_col, bool *allowed_colors);
+byte COL_FindColor(const byte *palette, u32_t rgb_col, bool *colors_allowed);
 byte COL_MapColor(u32_t rgb_col);
-byte COL_MapColor(u32_t rgb_col, bool *allowed_colors);
+byte COL_MapColor(u32_t rgb_col, bool *colors_allowed);
 
 void COL_LoadPaletteFromFile(const char *filename);
 

--- a/im_image.cc
+++ b/im_image.cc
@@ -196,6 +196,69 @@ rgb_image_c * rgb_image_c::NiceMip()
 }
 
 
+rgb_image_c * rgb_image_c::AvgSelectMip()
+{
+  SYS_ASSERT((width  & 1) == 0);
+  SYS_ASSERT((height & 1) == 0);
+
+  int new_w = width  / 2;
+  int new_h = height / 2;
+
+  u32_t pixels_original[4];
+
+  rgb_image_c *copy = new rgb_image_c(new_w, new_h);
+
+  for (int y = 0; y < new_h; y++)
+  for (int x = 0; x < new_w; x++)
+  {
+    int R = 0, G = 0, B = 0, A = 0;
+    int idx_original = 0;
+
+    for (int dy = 0; dy < 2; dy++)
+    for (int dx = 0; dx < 2; dx++)
+    {
+      u32_t cur = PixelAt(x*2+dx, y*2+dy);
+      
+      // save original pixel values, we'll select best match later
+      pixels_original[idx_original++] = cur;
+
+      R += RGB_R(cur); G += RGB_G(cur);
+      B += RGB_B(cur); A += RGB_A(cur);
+    }
+
+    R /= 4; G /= 4;
+    B /= 4; A /= 4;
+
+    // select original pixel that matches average color best
+    int32_t best_error = 2000000000;
+    u32_t pixel_selected = 0;
+    for(int i = 0; i < 4; i++) {
+      u32_t cur = pixels_original[i];
+      int32_t error = 0;
+
+      int diff = RGB_R(cur) - R;
+      error += diff * diff;
+      diff = RGB_G(cur) - G;
+      error += diff * diff;
+      diff = RGB_B(cur) - B;
+      error += diff * diff;
+      diff = RGB_A(cur) - A;
+      error += diff * diff;
+
+      if(error < best_error)
+      {
+        best_error = error;
+        pixel_selected = cur;
+      }
+    }
+
+    copy->PixelAt(x, y) = pixel_selected;
+  }
+
+
+  return copy;
+}
+
 void rgb_image_c::QuakeSkyFix()
 {
   for (int y = 0; y < height; y++)

--- a/im_image.h
+++ b/im_image.h
@@ -99,6 +99,10 @@ public:
   // duplicate the image, scaling it exactly in half on each axis
   // (hence the image MUST have an even width and height).
 
+  rgb_image_c * NiceSelectMip();
+  // duplicate the image, scaling it exactly in half on each axis
+  // (hence the image MUST have an even width and height).
+
   void QuakeSkyFix();
   // replaces solid black pixels in the left half of the image
   // with transparent parts.  Used for processing Quake 1 skies.

--- a/im_image.h
+++ b/im_image.h
@@ -95,6 +95,9 @@ public:
   // duplicate the image, scaling it exactly in half on each axis
   // (hence the image MUST have an even width and height).
 
+  rgb_image_c * AvgSelectMip();
+  // duplicate the image, scaling it exactly in half on each axis
+  // (hence the image MUST have an even width and height).
 
   void QuakeSkyFix();
   // replaces solid black pixels in the left half of the image

--- a/im_mip.cc
+++ b/im_mip.cc
@@ -411,7 +411,7 @@ bool MIP_ProcessImage(const char *filename)
 
   for (int mip = 1; mip < MIP_LEVELS; mip++)
   {
-    rgb_image_c *tmp = img->AvgSelectMip();
+    rgb_image_c *tmp = img->NiceSelectMip();
 
     delete img; img = tmp;
 

--- a/im_mip.cc
+++ b/im_mip.cc
@@ -415,7 +415,7 @@ bool MIP_ProcessImage(const char *filename)
 
     delete img; img = tmp;
 
-    MIP_ConvertImage(img, true, nullptr, colors_used);
+    MIP_ConvertImage(img, false, nullptr, colors_used);
   }
 
   WAD2_FinishLump();

--- a/im_mip.cc
+++ b/im_mip.cc
@@ -411,7 +411,7 @@ bool MIP_ProcessImage(const char *filename)
 
   for (int mip = 1; mip < MIP_LEVELS; mip++)
   {
-    rgb_image_c *tmp = img->NiceMip();
+    rgb_image_c *tmp = img->AvgSelectMip();
 
     delete img; img = tmp;
 

--- a/im_mip.cc
+++ b/im_mip.cc
@@ -411,16 +411,16 @@ bool MIP_ProcessImage(const char *filename)
 
   for (int mip = 1; mip < MIP_LEVELS; mip++)
   {
-    rgb_image_c *tmp = img->NiceSelectMip();
+    rgb_image_c *tmp;
     switch(opt_mip)
     {
-      case 0:
+      case MIP_NICE:
         tmp = img->NiceMip();
         break;
-      case 1:
+      case MIP_AVG_SELECT:
         tmp = img->AvgSelectMip();
         break;
-      case 2:
+      case MIP_NICE_SELECT:
         tmp = img->NiceSelectMip();
         break;
       default:

--- a/im_mip.cc
+++ b/im_mip.cc
@@ -412,6 +412,20 @@ bool MIP_ProcessImage(const char *filename)
   for (int mip = 1; mip < MIP_LEVELS; mip++)
   {
     rgb_image_c *tmp = img->NiceSelectMip();
+    switch(opt_mip)
+    {
+      case 0:
+        tmp = img->NiceMip();
+        break;
+      case 1:
+        tmp = img->AvgSelectMip();
+        break;
+      case 2:
+        tmp = img->NiceSelectMip();
+        break;
+      default:
+        FatalError("Invalid MIP algorithm selected: %d\n", opt_mip);
+    }
 
     delete img; img = tmp;
 

--- a/im_mip.cc
+++ b/im_mip.cc
@@ -172,12 +172,18 @@ std::string MIP_FileToLumpName(const char *filename, bool * fullbright)
 }
 
 
-void MIP_ConvertImage(rgb_image_c *img, bool dither = false)
+void MIP_ConvertImage(rgb_image_c *img, bool dither = false, bool *colors_used = nullptr, bool *colors_allowed = nullptr)
 {
   byte *line_buf = new byte[img->width];
   s16_t *err_buf = new s16_t[img->width * 3];
 
   memset(err_buf, 0, sizeof(s16_t) * img->width * 3);
+
+  // reset buffer of used palette colors, if provided
+  if(colors_used != nullptr)
+  {
+    memset(colors_used, false, sizeof(bool) * 256);
+  }
 
   for (int y = 0; y < img->height; y++)
   {
@@ -213,9 +219,14 @@ void MIP_ConvertImage(rgb_image_c *img, bool dither = false)
         if (b & 0xF00) b = (b < 0) ? 0 : 255;
 
         // store pixel
-        byte pix = COL_MapColor(MAKE_RGBA(r, g, b, alpha));
+        byte pix = COL_MapColor(MAKE_RGBA(r, g, b, alpha), colors_allowed);
 
         *dest++ = pix;
+
+        if(colors_used != nullptr)
+        {
+          colors_used[pix] = true;
+        }
 
         // determine new error
         u32_t got = COL_ReadPalette(pix);
@@ -233,7 +244,13 @@ void MIP_ConvertImage(rgb_image_c *img, bool dither = false)
     {
       for (; src < src_e; src++)
       {
-        *dest++ = COL_MapColor(*src);
+        byte pix = COL_MapColor(*src, colors_allowed);
+        *dest++ = pix;
+
+        if(colors_used != nullptr)
+        {
+          colors_used[pix] = true;
+        }
       }
     }
 
@@ -385,9 +402,12 @@ bool MIP_ProcessImage(const char *filename)
   COL_SetTransparent(0);
   COL_SetFullBright(fullbright);
 
+  // array to store which palette colors were used in MIP level zero
+  bool *colors_used = new bool[256];
 
   // now the actual textures
-  MIP_ConvertImage(img, opt_dither);
+  // first convert MIP level zero, gather data on used colors
+  MIP_ConvertImage(img, opt_dither, colors_used, nullptr);
 
   for (int mip = 1; mip < MIP_LEVELS; mip++)
   {
@@ -395,11 +415,12 @@ bool MIP_ProcessImage(const char *filename)
 
     delete img; img = tmp;
 
-    MIP_ConvertImage(img, true);
+    MIP_ConvertImage(img, true, nullptr, colors_used);
   }
 
   WAD2_FinishLump();
 
+  delete[] colors_used;
   delete img;
   return true;
 }

--- a/main.cc
+++ b/main.cc
@@ -58,6 +58,7 @@ bool opt_force   = false;
 bool opt_raw     = false;
 bool opt_picture = false;
 bool opt_dither  = false;
+int  opt_mip     = 2;
 
 
 void FatalError(const char *message, ...)
@@ -96,6 +97,7 @@ void ShowUsage(void)
   printf("   -l  -list        list contents of PAK/WAD file\n");
   printf("   -e  -extract     extract PAK/WAD contents into current dir\n");
   printf("   -m  -maketex     make a texture WAD from BSP files\n");
+  printf("   -mip             select MIP algorithm, 0, 1 or 2 (default)\n");
   printf("\n");
 
   printf("   -c  -colors XXX  load color palette from given file\n");
@@ -156,6 +158,26 @@ int HandleOption(int argc, char **argv)
     return 1;
   }
 
+  if (StringCaseCmp(opt, "-mip") == 0)
+  {
+    if (argc <= 1 || argv[1][0] == '-')
+      FatalError("Missing MIP algorithm after %s\n", argv[0]);
+    
+    try
+    {
+      opt_mip = std::stoi(argv[1]);
+    } catch(...)
+    {
+      FatalError("Invalid value for MIP algorithm\n");
+    }
+    
+    if(opt_mip < 0 || opt_mip > 2)
+    {
+      FatalError("Invalid MIP algorithm selected: %d\n", opt_mip);
+    }
+
+    return 2;
+  }
 
   if (StringCaseCmp(opt, "-c") == 0 || StringCaseCmp(opt, "-color") == 0 ||
       StringCaseCmp(opt, "-colors") == 0)

--- a/main.cc
+++ b/main.cc
@@ -58,7 +58,7 @@ bool opt_force   = false;
 bool opt_raw     = false;
 bool opt_picture = false;
 bool opt_dither  = false;
-int  opt_mip     = 2;
+int  opt_mip     = MIP_NICE_SELECT;
 
 
 void FatalError(const char *message, ...)

--- a/main.cc
+++ b/main.cc
@@ -98,6 +98,9 @@ void ShowUsage(void)
   printf("   -e  -extract     extract PAK/WAD contents into current dir\n");
   printf("   -m  -maketex     make a texture WAD from BSP files\n");
   printf("   -mip             select MIP algorithm, 0, 1 or 2 (default)\n");
+  printf("        0: high-quality downsampling\n");
+  printf("        1: averaging four pixels, then selecting the original color closest\n           to the average\n");
+  printf("        2: high-quality downsampling, then selecting the original color closest\n           to the downsampling result\n");
   printf("\n");
 
   printf("   -c  -colors XXX  load color palette from given file\n");

--- a/main.h
+++ b/main.h
@@ -29,10 +29,13 @@ typedef enum
 }
 game_kind_e;
 
+#define MIP_NICE 0
+#define MIP_AVG_SELECT 1
+#define MIP_NICE_SELECT 2
+
 extern game_kind_e game_type;
 
 extern std::string color_name;
-
 
 extern bool opt_force;
 extern bool opt_picture;

--- a/main.h
+++ b/main.h
@@ -38,6 +38,7 @@ extern bool opt_force;
 extern bool opt_picture;
 extern bool opt_raw;
 extern bool opt_dither;
+extern int  opt_mip;
 
 
 void FatalError(const char *str, ...);


### PR DESCRIPTION
This set of changes includes:

* MIP-textures now are restricted to colors already utilized in MIP0 (the original texture). This change is especially helpful for texture with fullbright parts, but also avoids using muddled in-between colors in other cases.
* Disabled dithering for MIP1 to MIP3. The introduced noise somewhat diminished the reason for having MIP-textures in the first place.
* If enabled, fullbright colors now take precedence over non-fullbright color duplicates (the Quake palette has some duplicates).
* Introducing the command-line parameter "-mip", with values 0, 1 and 2.
  1. 0 is high-quality downsampling
  2. 1 is averaging four pixel values, then selecting the original color closest to the average
  3. 2 is using high-quality downsampling, then selecting the original color closest to the downsampling result (default)
 