### PR TITLE
Support for transparent textures without _fbr naming suffix

### DIFF
--- a/im_color.cc
+++ b/im_color.cc
@@ -352,13 +352,19 @@ byte COL_FindColor(const byte *palette, u32_t rgb_col, bool *colors_allowed)
   // Note: we skip index #0 (black), which is used for transparency
   //       in skies.  Black is duplicated at index #48 though.
   int min_col = (game_type == GAME_Quake1) ? 1 : 0;
-  int max_col = allow_fullbright ? 255 : 255-32;
 
   // iterate through the color palette *backwards*, so that fullbright colors
   // have precedence over non-fullbright colors
   // (of course only if fullbright colors are enabled)
-  for (int i = max_col; i >= min_col; i--)
+  for (int i = 255; i >= min_col; i--)
   {
+    // skip fullbright colors if fullbrights are not enabled.
+    // Don't skip for the transparent color.
+    if(!allow_fullbright && i >= (255-32) && i != transparent_color)
+    {
+      continue;
+    }
+
     // if an array of allowed colors is provided, skip colors not allowed
     if(colors_allowed != nullptr && !colors_allowed[i])
     {

--- a/im_color.cc
+++ b/im_color.cc
@@ -360,7 +360,7 @@ byte COL_FindColor(const byte *palette, u32_t rgb_col, bool *colors_allowed)
   {
     // skip fullbright colors if fullbrights are not enabled.
     // Don't skip for the transparent color.
-    if(!allow_fullbright && i >= (255-32) && i != transparent_color)
+    if(!allow_fullbright && i > (255-32) && i != transparent_color)
     {
       continue;
     }

--- a/im_mip.cc
+++ b/im_mip.cc
@@ -402,6 +402,11 @@ bool MIP_ProcessImage(const char *filename)
   COL_SetTransparent(0);
   COL_SetFullBright(fullbright);
 
+  // Quake1: If the texture names starts with "{", then enable transparency
+  if(game_type == GAME_Quake1 && lump_name.rfind("{", 0) == 0) {
+    COL_SetTransparent(255);
+  }
+
   // array to store which palette colors were used in MIP level zero
   bool *colors_used = new bool[256];
 

--- a/im_mip.cc
+++ b/im_mip.cc
@@ -403,7 +403,8 @@ bool MIP_ProcessImage(const char *filename)
   COL_SetFullBright(fullbright);
 
   // Quake1: If the texture names starts with "{", then enable transparency
-  if(game_type == GAME_Quake1 && lump_name.rfind("{", 0) == 0) {
+  if(game_type == GAME_Quake1 && lump_name.rfind("{", 0) == 0)
+  {
     COL_SetTransparent(255);
   }
 


### PR DESCRIPTION
This introduces special support for textures with transparent texels (textures with a name starting with "{").

The color index for transparent texels is index 255 in the Quake palette, which is in the range of fullbright colors. Thus, currently, transparent textures need a "_fbr" suffix to enable this part of the palette. However, this can lead to transparent textures having unintended fullbright texels, as there are duplicate color entries in the fullbright and non-fullbright parts of the color palette.

With these changes, textures with the "{" prefix will have color index 255 available automatically, without enabling the rest of the fullbright palette.